### PR TITLE
#164325129 - Allow User to GET offices

### DIFF
--- a/api/ver2/endpoints/offices.py
+++ b/api/ver2/endpoints/offices.py
@@ -16,9 +16,9 @@ office_v2 = Blueprint('offices_v2', __name__)
 @jwt_required
 def add_or_get_all_ep():
     try:
-        if is_not_admin():
-            return is_not_admin()
         if request.method == post_method:
+            if is_not_admin():
+                return is_not_admin()
             fields = [name_key, type_key]
             data = check_form_data(office_key, request, fields)
             if not data:
@@ -58,6 +58,8 @@ def get_office_delete_ep(id):
             else:
                 return not_found_resp(office_key)
         elif request.method == delete_method:
+            if is_not_admin():
+                return is_not_admin()
             office = Office(Id=id)
             if office.get_by('id', id):
                 p = office.get_by('id', id)


### PR DESCRIPTION
The Politico API only allows the admin to access political offices list. However, in order to view the available political offices and to be able to vote, the normal user needs to access the offices' list via GET.