### PR TITLE
#164443647 Use send grid module to sent reset password link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - psql -c "CREATE DATABASE politico_test;" -U postgres
 
 env:
-  - DATABASE_URL="dbname='politico' host='127.0.0.1' port='5432' user='postgres' password='kadanieet'" TEST_DATABASE_URL="dbname='politico_test' host='127.0.0.1' port='5432' user='postgres' password='kadanieet'" SECRET="jwt-secret-string" APP_SETTINGS='testing' ADMIN_MAIL="w.gichuhi5@students.ku.ac.ke" ADMIN_PASS="kadanieet"
+  - DATABASE_URL="dbname='politico' host='127.0.0.1' port='5432' user='postgres' password='kadanieet'" TEST_DATABASE_URL="dbname='politico_test' host='127.0.0.1' port='5432' user='postgres' password='kadanieet'" SECRET="jwt-secret-string" APP_SETTINGS='testing' ADMIN_MAIL="w.gichuhi5@students.ku.ac.ke" ADMIN_PASS="kadanieet" SENDGRID_API_KEY="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" SENDGRID_DEFAULT_FROM="politco-noreply@politico.com"
 
 # command to automate tests
 script:

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -13,7 +13,7 @@ from api.ver2.endpoints.candidature import candids
 from api.strings import status_400, status_404, status_405
 from api.ver2.database.model import Database
 from flask_jwt_extended import JWTManager
-from flask_mail import Mail, Message
+from flask_sendgrid import SendGrid
 from flask_cors import CORS
 from .strings import *
 import os
@@ -58,18 +58,6 @@ def create_app(config_name):
 
     CORS(app)
     jwt = JWTManager(app)
-    mail = Mail(app)  # Create an instance of Mail class.
-
-    @app.route('/mailer', methods=['POST'])
-    def mailer():
-        data = request.get_json()
-        msg = Message(
-            data['subject'],
-            recipients=data['recipients'],
-            sender=os.getenv('MAIL_USERNAME')
-        )
-        msg.body = data['body']
-        mail.send(msg)
 
     @app.errorhandler(status_400)
     def bad_request(error):

--- a/api/ver1/users/models.py
+++ b/api/ver1/users/models.py
@@ -10,7 +10,7 @@ users = [
         id_key : 1,
         fname : 'john',
         lname : 'doe',
-        email: 'johndoe@andela.com',
+        email: 'muffwaindan@gmail.com',
         phone: '0713972278',
         pspt : 'passport.jpg', admin: False
     },

--- a/api/ver2/endpoints/auth.py
+++ b/api/ver2/endpoints/auth.py
@@ -152,9 +152,13 @@ def reset():
                                 reset_markup:
                             text = reset_markup.read().replace('\n', '')
                             text = text.replace('action_url', reset_url)
-                            text = text.replace(
-                                'username',
-                                User().get_by_id(2)['fname'])
+                            try:
+                                text = text.replace(
+                                    'username',
+                                    User().get_by_id(user['id'])['fname'])
+                            except Exception:
+                                return error('Admin Not Allowed To Reset '
+                                             'Password!', 400)
 
                         from_email = Email("politico-noreply@politico.com")
                         to_email = Email(mail)

--- a/instance/config.py
+++ b/instance/config.py
@@ -6,6 +6,8 @@ class Config(object):
     """Parent configuration class."""
     DEBUG = False
     SECRET = os.getenv('SECRET')
+    SENDGRID_API_KEY = os.getenv('SENDGRID_API_KEY')
+    SENDGRID_DEFAULT_FROM = os.getenv('SENDGRID_DEFAULT_FROM')
 
 
 class DevelopmentConfig(Config):

--- a/pass_reset_markup.html
+++ b/pass_reset_markup.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Set up a new password for your Politico&trade; - gVotie</title>
+
+
+  </head>
+  <body style="-webkit-text-size-adjust: none; box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; height: 100%; line-height: 1.4; margin: 0; width: 100% !important;" bgcolor="#F2F4F6"><style type="text/css">
+body {
+width: 100% !important; height: 100%; margin: 0; line-height: 1.4; background-color: #F2F4F6; color: #74787E; -webkit-text-size-adjust: none;
+}
+@media only screen and (max-width: 600px) {
+  .email-body_inner {
+    width: 100% !important;
+  }
+  .email-footer {
+    width: 100% !important;
+  }
+}
+@media only screen and (max-width: 500px) {
+  .button {
+    width: 100% !important;
+  }
+}
+</style>
+    <span class="preheader" style="box-sizing: border-box; display: none !important; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 1px; line-height: 1px; max-height: 0; max-width: 0; mso-hide: all; opacity: 0; overflow: hidden; visibility: hidden;">Use this link to reset your password. The link is only valid for 24 hours.</span>
+    <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 0; width: 100%;" bgcolor="#F2F4F6">
+      <tr>
+        <td align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+          <table class="email-content" width="100%" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 0; width: 100%;">
+            <tr>
+              <td class="email-masthead" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; padding: 25px 0; word-break: break-word;" align="center">
+                <a href="https://url.com" class="email-masthead_name" style="box-sizing: border-box; color: #bbbfc3; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; font-weight: bold; text-decoration: none; text-shadow: 0 1px 0 white;">
+        Politico&trade;
+      </a>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="email-body" width="100%" cellpadding="0" cellspacing="0" style="-premailer-cellpadding: 0; -premailer-cellspacing: 0; border-bottom-color: #EDEFF2; border-bottom-style: solid; border-bottom-width: 1px; border-top-color: #EDEFF2; border-top-style: solid; border-top-width: 1px; box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 0; width: 100%; word-break: break-word;" bgcolor="#FFFFFF">
+                <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0 auto; padding: 0; width: 570px;" bgcolor="#FFFFFF">
+
+                  <tr>
+                    <td class="content-cell" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; padding: 35px; word-break: break-word;">
+                      <h1 style="box-sizing: border-box; color: #2F3133; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 19px; font-weight: bold; margin-top: 0;" align="left">Hi username,</h1>
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">You recently requested to reset your password for your Politico&trade; - gVotie account. Use the button below to reset it.
+
+                      <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 30px auto; padding: 0; text-align: center; width: 100%;">
+                        <tr>
+                          <td align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+
+                            <table width="100%" border="0" cellspacing="0" cellpadding="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
+                              <tr>
+                                <td align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+                                  <table border="0" cellspacing="0" cellpadding="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
+                                    <tr>
+                                      <td style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+                                        <a href="action_url" class="button button--green" target="_blank" style="-webkit-text-size-adjust: none; background: #22BC66; border-color: #22bc66; border-radius: 3px; border-style: solid; border-width: 10px 18px; box-shadow: 0 2px 3px rgba(0, 0, 0, 0.16); box-sizing: border-box; color: #FFF; display: inline-block; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; text-decoration: none;">Reset your password</a>
+                                      </td>
+                                    </tr>
+                                  </table>
+                                </td>
+                              </tr>
+                            </table>
+                          </td>
+                        </tr>
+                      </table>
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">If you did not request a password reset, please ignore this email or <a href="mailto: w.gichuhi5@students.ku.ac.ke" style="box-sizing: border-box; color: #3869D4; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">contact support</a> if you have questions.</p>
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">Thanks,
+                        <br />The Politico&trade; - gVotie Team</p>
+
+                      <table class="body-sub" style="border-top-color: #EDEFF2; border-top-style: solid; border-top-width: 1px; box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin-top: 25px; padding-top: 25px;">
+                        <tr>
+                          <td style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+                            <p class="sub" style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 12px; line-height: 1.5em; margin-top: 0;" align="left">If you’re having trouble with the button above, copy and paste the URL below into your web browser.</p>
+                            <p class="sub" style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 12px; line-height: 1.5em; margin-top: 0;" align="left">action_url</p>
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+                <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0 auto; padding: 0; text-align: center; width: 570px;">
+                  <tr>
+                    <td class="content-cell" align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; padding: 35px; word-break: break-word;">
+                      <p class="sub align-center" style="box-sizing: border-box;
+                       color: #AEAEAE; font-family: Arial, 'Helvetica Neue',
+                       Helvetica, sans-serif; font-size: 12px; line-height: 1
+                       .5em; margin-top: 0;" align="center">© 2019 Politico -
+                       gVotie
+                       . All rights reserved.</p>
+                      <p class="sub align-center" style="box-sizing: border-box; color: #AEAEAE; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 12px; line-height: 1.5em; margin-top: 0;" align="center">
+                        Politico&trade; - gVotie
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ Flask-Cors==3.0.7
 Flask-JWT==0.3.2
 Flask-JWT-Extended==3.17.0
 Flask-Mail==0.9.1
+Flask-SendGrid==0.6
 gunicorn==19.9.0
 idna==2.8
 isort==4.3.4
@@ -34,7 +35,9 @@ pylint==2.2.2
 pytest==4.2.0
 pytest-cov==2.6.1
 python-dotenv==0.10.1
+python-http-client==3.1.0
 requests==2.21.0
+sendgrid==5.3.0
 six==1.12.0
 typed-ast==1.3.0
 urllib3==1.24.1


### PR DESCRIPTION
**What does this PR do?**
Adds the send password reset email feature on the backend API via sendgrid module.

**Description of Task to be completed?**
A User should be able to rest their Politico password.

**How should this be manually tested?**
To test this manually, clone the repo to your local system. Install and run the system as specified. Use an API client to test the reset endpoints. [reset_2](http://127.0.0.1:5000/api/v2/auth/reset/link/<string:token>) and [reset_1](http://127.0.0.1:5000/api/v2/auth/reset)

Alternatively, visit [Politico's Password Reset](https://wainainad60.github.io/Politico/templates/reset_pass.html) if you don't want to clone it locally.

What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/164443647

**Screenshots**
![image](https://user-images.githubusercontent.com/5586763/53966997-66fcdb80-4105-11e9-8a62-cb096e55d613.png)
